### PR TITLE
Improved error reporting

### DIFF
--- a/wp2tumblr.py
+++ b/wp2tumblr.py
@@ -81,9 +81,15 @@ for item in items:
 
 		page = response.read(200000)
 		print page
-	except Exception, detail:
-		print detail
-		sys.exit(2)
+	except HTTPError, e:
+	    print 'The server couldn\'t fulfill the request.'
+	    print 'Error code: ', e.code
+	    print e.read()
+	    sys.exit(2)
+	except URLError, e:
+	    print 'We failed to reach a server.'
+	    print 'Reason: ', e.reason
+	    sys.exit(2)
 
 	time.sleep(1) # don't overload the Tumblr API
 


### PR DESCRIPTION
If tumblr API blocks the request for some reason, that reason is now displayed.
e.g.. maximum of 100 posts per day reached
Came across that one while migrating my blog :)
