### PR TITLE
Support for comma separated custom tags

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -98,10 +98,15 @@ header .header-copyright a {
     -wekbit-border-radius: 10px;
 }
 
-
 .flash {
     background: #cdf;
     padding: 20px;
     font-size: 15px;
     color: #346;
 }
+
+.with-margins {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
+

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -9,16 +9,16 @@
             Please select the Wordpress export XML file you'd like to import. Visit Wordpress.org for more information about <a href="http://en.support.wordpress.com/export/">exporting a Wordpress blog</a>.
         </div>
 
-        <form method="post" action="/upload" enctype="multipart/form-data" id="upload-form">
-            <div>
+        <form class="pure-form" method="post" action="/upload" enctype="multipart/form-data" id="upload-form">
+            <div class="with-margins">
                 <input type="file" name="wordpress_xml" />
             </div>
 
-            <div>
+            <div class="with-margins">
                 <input type="text" name="custom_tags" placeholder="Custom tags"/>
             </div>
 
-            <div>
+            <div class="with-margins">
                 <input type="hidden" name="tumblog_name" value="{{ tumblog_name }}" />
                 <button type="submit" class="pure-button pure-button-primary">Submit</button>
             </div>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -15,6 +15,10 @@
             </div>
 
             <div>
+                <input type="text" name="custom_tags" placeholder="Custom tags"/>
+            </div>
+
+            <div>
                 <input type="hidden" name="tumblog_name" value="{{ tumblog_name }}" />
                 <button type="submit" class="pure-button pure-button-primary">Submit</button>
             </div>

--- a/wp2tumblr.py
+++ b/wp2tumblr.py
@@ -134,6 +134,14 @@ def upload():
 
     return render_template('upload.html', bloginfo=bloginfo, tumblog_name=tumblog_name)
 
+def parse_custom_tags(tags):
+    tagslist = tags.encode('utf-8').split(',')
+    retval = []
+
+    for tag in tagslist:
+        retval.append(tag.strip())
+
+    return retval
 
 def do_import(tumblog_name, xml_file, custom_tags):
     dom = minidom.parse(xml_file)
@@ -168,7 +176,7 @@ def do_import(tumblog_name, xml_file, custom_tags):
         post['tags'] = [x.firstChild.nodeValue.encode('utf-8', 'xmlcharrefreplace') for x in item.getElementsByTagName('category') if x.getAttribute('domain') == 'post_tag']
 
         if custom_tags:
-            post['tags'].append(custom_tags.encode('utf-8'))
+            post['tags'] += parse_custom_tags(custom_tags)
 
         if app.debug:
             print post

--- a/wp2tumblr.py
+++ b/wp2tumblr.py
@@ -101,6 +101,7 @@ def upload():
         return redirect(url_for('login'))
 
     tumblog_name = request.form.get('tumblog_name') or request.args.get('tumblog_name')
+    custom_tags = request.form.get('custom_tags') or request.args.get('custom_tags')
     if not tumblog_name:
         return redirect(url_for('index'))
 
@@ -111,7 +112,7 @@ def upload():
 
     if request.method == 'POST':
         # try:
-        post_count = do_import(tumblog_name, request.files['wordpress_xml'])
+        post_count = do_import(tumblog_name, request.files['wordpress_xml'], custom_tags)
         # except Exception, detail:
         #     print 'XML file must be well-formed. You\'ll need to edit the file to fix the problem.'
         #     print detail
@@ -134,7 +135,7 @@ def upload():
     return render_template('upload.html', bloginfo=bloginfo, tumblog_name=tumblog_name)
 
 
-def do_import(tumblog_name, xml_file):
+def do_import(tumblog_name, xml_file, custom_tags):
     dom = minidom.parse(xml_file)
 
     post_count = 0
@@ -165,6 +166,9 @@ def do_import(tumblog_name, xml_file):
         post['body'] = item.getElementsByTagName('content:encoded')[0].firstChild.nodeValue.encode('utf-8', 'xmlcharrefreplace')
 
         post['tags'] = [x.firstChild.nodeValue.encode('utf-8', 'xmlcharrefreplace') for x in item.getElementsByTagName('category') if x.getAttribute('domain') == 'post_tag']
+
+        if custom_tags:
+            post['tags'].append(custom_tags.encode('utf-8'))
 
         if app.debug:
             print post


### PR DESCRIPTION
Hi,
I wanted to have a basic custom tag support for my wp>tumblr import, so I extended the `do_import` function to accept a `custom_tags` parameter. After a bit of processing and strip I concatenate arrays in a final `post[tags]` list that contains everything.

I tested pretty much everything and this works well, if you have suggestions let me know. 👍

P.S.: I added some eye candy for the new form field 🎨 
